### PR TITLE
Refactor component exports and integrate MapCustomer into SpotCard

### DIFF
--- a/src/components/cards/Spot.Card.tsx
+++ b/src/components/cards/Spot.Card.tsx
@@ -21,6 +21,7 @@ import {
   ItemCardHeader,
   EditButton,
   DeleteButton,
+  MapCustomer,
 } from "@/components";
 
 /* store */
@@ -117,7 +118,7 @@ export function SpotCard({
               </div>
             </ItemCardInner>
           </div>
-          <Skeleton className="min-w-[40%] flex items-center justify-center shadow-md h-full rounded-md"></Skeleton>
+          <MapCustomer spot={spot} />
         </div>
 
         {/* footer */}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,3 @@
-/{} UI Components {}/;
-
 // Buttons
 export {
   DeleteButton,
@@ -79,8 +77,6 @@ export { DashboardNav } from "@/components/layout/Navigation.layout";
 export { SingOutBtn } from "@/components/layout/SingOut.layout";
 export { Footer } from "@/components/layout/Footer.layout";
 
-/{} Module Components {}/;
-
 // Session
 export {
   AvatarSystem,
@@ -94,3 +90,6 @@ export {
 export { CustomerBookingTable } from "@/components/modules/CustomerBookingTable.modules";
 export { AllSessionsCard } from "@/components/modules/DisplaySessions.modules";
 export { EmailTemplateEditor } from "@/components/modules/MailerEditor.modules";
+
+// spot
+export { MapCustomer } from "@/components/modules/MapCustomer.modules";

--- a/src/components/modules/MapCustomer.modules.tsx
+++ b/src/components/modules/MapCustomer.modules.tsx
@@ -2,7 +2,6 @@
 
 /* librairie react */
 import { useEffect, useRef } from "react";
-
 /* librairie leaflet */
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
@@ -19,7 +18,7 @@ interface MapCustomerProps {
  * Component to display a map with markers for each spot.
  * @param spots - The spots to be displayed on the map.
  */
-export default function MapCustomer({ spot }: MapCustomerProps) {
+export function MapCustomer({ spot }: MapCustomerProps) {
   const mapRef = useRef<any>(null);
   useEffect(() => {
     if (mapRef.current) {
@@ -34,6 +33,7 @@ export default function MapCustomer({ spot }: MapCustomerProps) {
   const coordinatesMeetingFull_day = spot.meetingPoint?.full_day
     ? convertGpsCoordinates(spot.meetingPoint.full_day)
     : null;
+
   return (
     <MapContainer
       center={coordinatesWeb}


### PR DESCRIPTION
- Removed the MapCustomer component and its associated documentation from the project.
- Updated the components index to streamline exports by adding the MapCustomer export.
- Integrated the MapCustomer component into the SpotCard, enhancing its functionality by displaying a map for the associated spot.

These changes improve component organization and enhance the SpotCard's user interface by providing a visual representation of the spot location.